### PR TITLE
Provide rpmfusion

### DIFF
--- a/chapeau-repos.spec
+++ b/chapeau-repos.spec
@@ -11,6 +11,8 @@ Requires:       chapeau-release
 Obsoletes:      fedora-repos-anaconda < 21-1
 Obsoletes:      fedora-repos-rawhide < 21-0.4
 Obsoletes:      fedora-release-rawhide <= 21-0.7
+Provides:       rpmfusion-free-release
+Provides:       rpmfusion-nonfree-release
 BuildArch:      noarch
 
 %description

--- a/chapeau-repos.spec
+++ b/chapeau-repos.spec
@@ -45,6 +45,10 @@ done
 /etc/pki/rpm-gpg/*
 
 %changelog
+
+* Thu Jul 16 2015 Chris Palmer(PhnxRbrn) <pennstate5013@gmail.com> 22
+- Added Provides RPMFusion
+
 * Wed Feb 04 2015 Vince Pooley 21-3
 - Added includepkg paterns to korora.repo
 


### PR DESCRIPTION
Since Chapeau integrates rpmfusion into their repo, the spec needs to provide the packages for any piece of software that requires the rpmfusion packages
